### PR TITLE
fix(waybar): correct network module unit display from bits to bytes

### DIFF
--- a/configs/waybar/config.jsonc
+++ b/configs/waybar/config.jsonc
@@ -37,7 +37,7 @@
     "interface": "enp6s0",
     "tooltip-format-ethernet": "{ifname}: {ipaddr}",
     "interval": 1,
-    "format": " {bandwidthDownBits}   {bandwidthUpBits}",
+    "format": " {bandwidthDownBytes}   {bandwidthUpBytes}",
     "format-disconnected": "⚠ Disconnected"
   },
 


### PR DESCRIPTION
Found that Waybar displayed network traffic values with the wrong unit, so changed it from Bits to Bytes.