### PR TITLE
fix: latest hyprland v0.53.0 config for blur windows

### DIFF
--- a/configs/hypr/hyprland/windows.conf
+++ b/configs/hypr/hyprland/windows.conf
@@ -1,7 +1,12 @@
-#layerrule = blur, waybar
-#layerrule = blur, rofi
+layerrule {
+  name = layerrule-1
+  blur = on
+  blur_popups = on
+  match:namespace = rofi
+  no_screen_share = on
+}
 
-#windowrule = blur, match:class rofi
+layerrule-1 = border_size 30
 
 general {
     gaps_in = 5


### PR DESCRIPTION
This pull request updates the `windows.conf` configuration for Hyprland, focusing on how blur effects are applied to the `rofi` namespace.